### PR TITLE
Feat/5 Oauth 2.0 로그인,회원가입 기능 추가 (Google, Kakao)

### DIFF
--- a/src/main/java/com/sparta/realtomatoapp/auth/config/ObjectMapperConfig.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/config/ObjectMapperConfig.java
@@ -1,0 +1,15 @@
+package com.sparta.realtomatoapp.auth.config;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.sparta.realtomatoapp.auth.config;
+
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/GoogleOauthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/GoogleOauthController.java
@@ -1,0 +1,40 @@
+package com.sparta.realtomatoapp.auth.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.realtomatoapp.auth.service.GoogleOauthService;
+import com.sparta.realtomatoapp.auth.service.KakaoOauthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/google")
+public class GoogleOauthController {
+
+    private final GoogleOauthService googleOauthService;
+
+
+    @GetMapping("/login")
+    public String redirectGoogleLogin(
+            @Value("${google.auth.url}") String authUrl,
+            @Value("${google.client.id}") String clientId,
+            @Value("${google.redirect.uri}") String redirectUri
+    ) {
+        return authUrl +
+                "?client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&response_type=code" +
+                "&scope=openid profile email";
+    }
+
+    @GetMapping("/callback")
+    public String callbackGoogleLogin(@RequestParam String code) throws JsonProcessingException {
+        String accessToken = googleOauthService.googleLogin(code);
+
+        return accessToken;
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/KakaoOauthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/KakaoOauthController.java
@@ -1,0 +1,39 @@
+package com.sparta.realtomatoapp.auth.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.realtomatoapp.auth.service.KakaoOauthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+//@RequestMapping("/api/oauth2.0/kakao")
+@RequestMapping("/api/auth/kakao")
+public class KakaoOauthController {
+
+    private final KakaoOauthService kakaoOauthService;
+
+
+    @GetMapping("/login")
+    public String redirectKakaoLogin(
+            @Value("${kakao.auth.url}") String authUrl,
+            @Value("${kakao.client.id}") String clientId,
+            @Value("${kakao.redirect.uri}") String redirectUri
+    ) {
+        return authUrl +
+                "?client_id=" + clientId +
+                "&redirect_uri=" + redirectUri +
+                "&response_type=code";
+    }
+
+    @GetMapping("/callback")
+    public String callbackKakaoLogin(@RequestParam String code) throws JsonProcessingException {
+        String accessToken = kakaoOauthService.kakaoLogin(code);
+
+        return accessToken;
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/dto/OauthUserInfo.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/dto/OauthUserInfo.java
@@ -1,0 +1,15 @@
+package com.sparta.realtomatoapp.auth.dto;
+
+import com.sparta.realtomatoapp.auth.entity.Provider;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OauthUserInfo {
+    private Long id;
+    private String oauthId;
+    private String nickname;
+    private String email;
+    private Provider provider;
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/entity/OauthUser.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/entity/OauthUser.java
@@ -1,0 +1,29 @@
+package com.sparta.realtomatoapp.auth.entity;
+
+import com.sparta.realtomatoapp.common.entity.BaseAuditingEntity;
+import com.sparta.realtomatoapp.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthUser extends BaseAuditingEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String oauthId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/entity/Provider.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/entity/Provider.java
@@ -1,0 +1,6 @@
+package com.sparta.realtomatoapp.auth.entity;
+
+public enum Provider {
+    KAKAO,
+    GOOGLE;
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/repository/OauthUserRepository.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/repository/OauthUserRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.realtomatoapp.auth.repository;
+
+import com.sparta.realtomatoapp.auth.entity.OauthUser;
+import com.sparta.realtomatoapp.auth.entity.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OauthUserRepository extends JpaRepository<OauthUser, Long> {
+    Optional<OauthUser> findByOauthIdAndProvider(String oauthId, Provider provider);
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/service/GoogleOauthService.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/service/GoogleOauthService.java
@@ -1,0 +1,153 @@
+package com.sparta.realtomatoapp.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sparta.realtomatoapp.auth.dto.OauthUserInfo;
+import com.sparta.realtomatoapp.auth.entity.OauthUser;
+import com.sparta.realtomatoapp.auth.entity.Provider;
+import com.sparta.realtomatoapp.auth.repository.OauthUserRepository;
+import com.sparta.realtomatoapp.security.util.PasswordEncoderUtil;
+import com.sparta.realtomatoapp.user.entity.User;
+import com.sparta.realtomatoapp.user.entity.UserRole;
+import com.sparta.realtomatoapp.user.entity.UserStatus;
+import com.sparta.realtomatoapp.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOauthService {
+
+    private final RestTemplate restTemplate;
+    private final PasswordEncoderUtil passwordEncoder;
+    private final UserRepository userRepository;
+    private final OauthUserRepository oauthUserRepository;
+
+    @Value("${google.client.id}")
+    private String clientId;
+
+    @Value("${google.client.secret}")
+    private String clientSecretId;
+
+    @Value("${google.redirect.uri}")
+    private String redirectUri;
+
+
+    public String googleLogin(String code) throws JsonProcessingException {
+        String accessToken = getAccessToken(code);
+        OauthUserInfo oauthUserInfo = getGoogleUserInfo(accessToken);
+        Optional<OauthUser> existingUserInfo = oauthUserRepository.findByOauthIdAndProvider(
+                oauthUserInfo.getOauthId(),
+                oauthUserInfo.getProvider()
+        );
+        // 만약 이전에 구글 OAUTH 로그인을 했던 기록이 있다면, Early Return
+        if(existingUserInfo.isPresent()) return accessToken;
+
+        // 첫 로그인 인데, 등록된 이메일이 없다면 회원 등록
+        User user = userRepository.findByEmail(oauthUserInfo.getEmail()).orElseGet(
+                () -> registerNewGoogleUser(oauthUserInfo)
+        );
+
+        // 구글 oauth 계정 등록
+        OauthUser googleUser = OauthUser.builder()
+                .oauthId(oauthUserInfo.getOauthId())
+                .provider(oauthUserInfo.getProvider())
+                .user(user)
+                .build();
+        oauthUserRepository.save(googleUser);
+
+        return accessToken;
+    }
+
+    private String getAccessToken(String code) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://oauth2.googleapis.com/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecretId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<Map> response = restTemplate.exchange(
+                requestEntity,
+                Map.class
+        );
+
+        // 응답받은 데이터들 추출
+        Map<String, Object> responseBody = response.getBody();
+        if (responseBody == null) {
+            throw new IllegalArgumentException("구글 엑세스 토큰 요청에 대한 응답이 비어있습니다.");
+        }
+
+        String accessToken = (String) responseBody.get("access_token");
+        String refreshToken = (String) responseBody.get("refresh_token"); // refresh token에 활용
+        Integer expiresIn = (Integer) responseBody.get("expires_in"); // 토큰 생명주기
+
+        return accessToken;
+    }
+
+    private OauthUserInfo getGoogleUserInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        String url = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode> res = restTemplate.exchange(url, HttpMethod.GET, entity, JsonNode.class);
+
+        JsonNode jsonNode = res.getBody();
+        String oauthId = jsonNode.get("id").asText();
+        String email = jsonNode.get("email").asText();
+        String name = jsonNode.get("name").asText();
+
+        return OauthUserInfo.builder()
+                .oauthId(oauthId)
+                .nickname(name)
+                .email(email)
+                .provider(Provider.GOOGLE)
+                .build();
+    }
+    private User registerNewGoogleUser(OauthUserInfo oauthUserInfo) {
+        User newUser = User.builder()
+                .email(oauthUserInfo.getEmail())
+                .userName(oauthUserInfo.getNickname())
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(UserRole.USER) // 최초 google 로그인 시 계정 일반 유저로 설정
+                .status(UserStatus.ACTIVE)
+                .address("주소를 변경해주세요.")
+                .build();
+
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/service/KakaoOauthService.java
@@ -1,0 +1,153 @@
+package com.sparta.realtomatoapp.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.realtomatoapp.auth.dto.OauthUserInfo;
+import com.sparta.realtomatoapp.auth.entity.OauthUser;
+import com.sparta.realtomatoapp.auth.entity.Provider;
+import com.sparta.realtomatoapp.auth.repository.OauthUserRepository;
+import com.sparta.realtomatoapp.security.util.PasswordEncoderUtil;
+import com.sparta.realtomatoapp.user.entity.User;
+import com.sparta.realtomatoapp.user.entity.UserRole;
+import com.sparta.realtomatoapp.user.entity.UserStatus;
+import com.sparta.realtomatoapp.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthService {
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+    private final PasswordEncoderUtil passwordEncoder;
+    private final UserRepository userRepository;
+    private final OauthUserRepository oauthUserRepository;
+
+
+
+    @Value("${kakao.client.id}")
+    private String clientId;
+    @Value("${kakao.redirect.uri}")
+    private String redirectUri;
+
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+        String accessToken = getAccessToken(code);
+        OauthUserInfo oauthUserInfo = getKakaoUserInfo(accessToken);
+        Optional<OauthUser> existingOauthUser = oauthUserRepository.findByOauthIdAndProvider(
+                oauthUserInfo.getOauthId(),
+                oauthUserInfo.getProvider()
+        );
+        // 만약 이전에 카카오 OAUTH 로그인을 했던 기록이 있다면, Early Return
+        if(existingOauthUser.isPresent()) return accessToken;
+
+        // 첫 로그인 인데, 등록된 이메일이 없다면 회원 등록
+        User user = userRepository.findByEmail(oauthUserInfo.getEmail()).orElseGet(
+                () -> registerNewKakaoUser(oauthUserInfo)
+        );
+
+        // 카카오 oauth 계정 등록
+        OauthUser kakaoUser = OauthUser.builder()
+                .oauthId(oauthUserInfo.getOauthId())
+                .provider(oauthUserInfo.getProvider())
+                .user(user)
+                .build();
+        oauthUserRepository.save(kakaoUser);
+
+        return accessToken;
+    }
+
+    private User registerNewKakaoUser(OauthUserInfo oauthUserInfo) {
+        User newUser = User.builder()
+                .email(oauthUserInfo.getEmail())
+                .userName(oauthUserInfo.getNickname())
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(UserRole.USER) // 최초 kakao 로그인 시 계정 일반 유저로 설정
+                .status(UserStatus.ACTIVE)
+                .address("주소를 변경해주세요.")
+                .build();
+
+        return userRepository.save(newUser);
+    }
+
+    private String getAccessToken(String code) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = objectMapper.readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    private OauthUserInfo getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+        String url = "https://kapi.kakao.com/v2/user/me";
+
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode> res = restTemplate.exchange(url, HttpMethod.GET, entity, JsonNode.class);
+
+        JsonNode jsonNode = res.getBody();
+        String oauthId = jsonNode.get("id").toString();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        return OauthUserInfo.builder()
+                .oauthId(oauthId)
+                .nickname(nickname)
+                .email(email)
+                .provider(Provider.KAKAO)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 public class JwtConfig {
 
     // 토큰의 만료 시간 (분 단위)
-    @Value("${acess.token.expire.time}")
+    @Value("${access.token.expire.time}")
     private Integer jwtaccesstokenexpiretime;
 
     // 서명 키 (secret key)

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
@@ -17,6 +17,6 @@ public class JwtConfig {
     private Integer jwtaccesstokenexpiretime;
 
     // 서명 키 (secret key)
-    @Value("${acess.token.secret.key}")
+    @Value("${access.token.secret.key}")
     private String jwtaccessTokenSecretKey;
 }


### PR DESCRIPTION
# 🍅title: Oauth 2.0 로그인,회원가입 기능 추가 (Google, Kakao)🍅 
## 🔘Part 
- Oauth 2.0 로그인,회원가입 파트 

## 🔎 작업 내용 
- 카카오, 구글 Oauth 로그인 기능을 추가하였습니다.
- 최초 로그인 시에 회원가입이 자동으로 되게끔 로직을 구성하였습니다.
- 이미 같은 이메일로 가입해둔 유저가 있다면 최초 로그인을 하더라도 회원가입이 되지 않도록 작성하였습니다.

## 🔧 앞으로의 과제 
- 현재 email을 기준으로 중복되는 유저가 없을 시 회원가입으로 하고있는데, sns 다른 provider(구글, 카카오)를 이용한다는 것 자체가 email이 다르기 때문에 한 사람이 두개의 계정을 갖게 되어 따로 로그인 되는 문제가 있습니다. 만약 추가한다면 로그인 후 추가 정보를 입력받게 리다이렉트 된다든지 하는 기능을 고려해봐야 할 것 같습니다.
- 서비스 로직이 같으면서도 조금씩 다른 형태로 되어있습니다. 일단 기능 동작을 위해 분리만 시켜두었는데, 중복코드가 많이 보입니다. 추후에 아무래도 리펙토링이 필요할 것 같습니다.. ㅠ
- 로그인 인증 이후 **jwt토큰을 만들어  헤더에 담는 로직이 필요할 것 같습니다.**


## ➕ 이슈 링크 
- [이슈 번호 5번](https://github.com/IwannabeArealTomato/tomato-app/issues/5)