### PR TITLE
Feat: Refresh 토큰 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'mysql:mysql-connector-java:8.0.33' // MySQL Connector 추가
     implementation 'org.projectlombok:lombok'
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
     annotationProcessor 'org.projectlombok:lombok'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3', 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     implementation 'org.springframework.security:spring-security-crypto:5.8.0'
 

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
@@ -64,6 +64,7 @@ public class AuthController {
                 .data(Collections.singletonList(userResponseDto))
                 .build());
     }
+
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponseDto> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
         log.info("AuthController.refreshAccessToken");

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
@@ -9,10 +9,12 @@ import com.sparta.realtomatoapp.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -24,29 +26,30 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<BaseResponseDto> login(@RequestBody LoginRequestDto request) {
-        log.info("AuthController.login");
+        log.info("Attempting login for email: {}", request.getEmail());
 
         try {
-            String jwtToken = userService.loginUser(request);
+            Map<String, String> tokens = userService.loginUserWithTokens(request);
+            String accessToken = tokens.get("accessToken");
+            String refreshToken = tokens.get("refreshToken");
 
             HttpHeaders headers = new HttpHeaders();
-            headers.add("Authorization", "Bearer " + jwtToken);
+            headers.add("Authorization", "Bearer " + accessToken);
+            headers.add("RefreshToken", refreshToken);
+
+            log.info("Login successful for email: {}", request.getEmail());
 
             return ResponseEntity.ok()
                     .headers(headers)
-                    .body(
-                            BaseResponseDto.baseResponseBuilder()
-                                .message("로그인 성공")
-                                .build()
-                    );
-
+                    .body(BaseResponseDto.baseResponseBuilder()
+                            .message("로그인 성공")
+                            .build());
         } catch (IllegalArgumentException e) {
+            log.error("Login failed for email: {} - Reason: {}", request.getEmail(), e.getMessage());
             return ResponseEntity.badRequest()
-                    .body(
-                            BaseResponseDto.baseResponseBuilder()
-                            .message("로그인 실패" + e.getMessage())
-                            .build()
-                    );
+                    .body(BaseResponseDto.baseResponseBuilder()
+                            .message("로그인 실패: " + e.getMessage())
+                            .build());
         }
     }
 
@@ -54,14 +57,44 @@ public class AuthController {
     public ResponseEntity<DataResponseDto> signup(@RequestBody UserRegistrationRequestDto request) {
         log.info("AuthController.signup");
 
-        // 사용자 등록
         UserResponseDto userResponseDto = userService.registerUser(request);
 
-        return ResponseEntity.ok(
-                DataResponseDto.<UserResponseDto>dataResponseBuilder()
+        return ResponseEntity.ok(DataResponseDto.<UserResponseDto>dataResponseBuilder()
                 .message("회원 가입 성공")
-                .data(List.of(userResponseDto))
-                .build()
-        );
+                .data(Collections.singletonList(userResponseDto))
+                .build());
+    }
+    @PostMapping("/refresh")
+    public ResponseEntity<BaseResponseDto> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        log.info("AuthController.refreshAccessToken");
+
+        if (!userService.verifyRefreshToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN) // 변경
+                    .body(BaseResponseDto.baseResponseBuilder()
+                            .message("유효하지 않은 또는 만료된 Refresh Token입니다.")
+                            .build());
+        }
+
+        String newAccessToken = userService.refreshAccessToken(refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + newAccessToken);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(BaseResponseDto.baseResponseBuilder()
+                        .message("Access Token 재발급 성공")
+                        .build());
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponseDto> logout(@RequestHeader("Refresh-Token") String refreshToken) {
+        log.info("AuthController.logout");
+
+        userService.invalidateRefreshToken(refreshToken);
+
+        return ResponseEntity.ok(BaseResponseDto.baseResponseBuilder()
+                .message("로그아웃 성공")
+                .build());
     }
 }

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/AuthController.java
@@ -1,23 +1,23 @@
 package com.sparta.realtomatoapp.auth.controller;
 
+import com.sparta.realtomatoapp.auth.dto.LoginRequestDto;
 import com.sparta.realtomatoapp.auth.dto.LoginTokenResponseDto;
 import com.sparta.realtomatoapp.auth.dto.UserRegistrationRequestDto;
 import com.sparta.realtomatoapp.auth.dto.UserResponseDto;
 import com.sparta.realtomatoapp.common.dto.BaseResponseDto;
 import com.sparta.realtomatoapp.common.dto.DataResponseDto;
-import com.sparta.realtomatoapp.auth.dto.LoginRequestDto;
 import com.sparta.realtomatoapp.security.config.JwtProvider;
 import com.sparta.realtomatoapp.user.service.UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collections;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -67,38 +67,4 @@ public class AuthController {
                 .data(Collections.singletonList(userResponseDto))
                 .build());
     }
-
-    /*@PostMapping("/refresh")
-    public ResponseEntity<BaseResponseDto> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        log.info("AuthController.refreshAccessToken");
-
-        if (!userService.verifyRefreshToken(refreshToken)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN) // 변경
-                    .body(BaseResponseDto.baseResponseBuilder()
-                            .message("유효하지 않은 또는 만료된 Refresh Token입니다.")
-                            .build());
-        }
-
-        String newAccessToken = userService.refreshAccessToken(refreshToken);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + newAccessToken);
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(BaseResponseDto.baseResponseBuilder()
-                        .message("Access Token 재발급 성공")
-                        .build());
-    }*/
-
-    /*@PostMapping("/logout")
-    public ResponseEntity<BaseResponseDto> logout(@RequestHeader("Refresh-Token") String refreshToken) {
-        log.info("AuthController.logout");
-
-        userService.invalidateRefreshToken(refreshToken);
-
-        return ResponseEntity.ok(BaseResponseDto.baseResponseBuilder()
-                .message("로그아웃 성공")
-                .build());
-    }*/
 }

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/GoogleOauthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/GoogleOauthController.java
@@ -1,10 +1,14 @@
 package com.sparta.realtomatoapp.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.realtomatoapp.auth.dto.OauthLoginResponseDto;
 import com.sparta.realtomatoapp.auth.service.GoogleOauthService;
-import com.sparta.realtomatoapp.auth.service.KakaoOauthService;
+import com.sparta.realtomatoapp.common.dto.BaseResponseDto;
+import com.sparta.realtomatoapp.security.config.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GoogleOauthController {
 
     private final GoogleOauthService googleOauthService;
+    private final JwtProvider jwtProvider;
 
 
     @GetMapping("/login")
@@ -32,9 +37,29 @@ public class GoogleOauthController {
     }
 
     @GetMapping("/callback")
-    public String callbackGoogleLogin(@RequestParam String code) throws JsonProcessingException {
-        String accessToken = googleOauthService.googleLogin(code);
+    public ResponseEntity<BaseResponseDto> callbackGoogleLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
 
-        return accessToken;
+        try {
+            OauthLoginResponseDto tokens = googleOauthService.googleLogin(code);
+
+            // 헤더와 쿠키에 엑세스토큰 과 리프레시 토큰을 저장
+            jwtProvider.addAccessTokenToHeader(response, tokens.getAccessToken());
+            jwtProvider.addRefreshTokenToCookie(response, tokens.getRefreshToken());
+
+            return ResponseEntity.ok()
+                    .body(
+                            BaseResponseDto.baseResponseBuilder()
+                                    .message("로그인 성공")
+                                    .build()
+                    );
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(
+                            BaseResponseDto.baseResponseBuilder()
+                                    .message("로그인 실패" + e.getMessage())
+                                    .build()
+                    );
+        }
     }
 }

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/KakaoOauthController.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/KakaoOauthController.java
@@ -1,9 +1,14 @@
 package com.sparta.realtomatoapp.auth.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sparta.realtomatoapp.auth.dto.OauthLoginResponseDto;
 import com.sparta.realtomatoapp.auth.service.KakaoOauthService;
+import com.sparta.realtomatoapp.common.dto.BaseResponseDto;
+import com.sparta.realtomatoapp.security.config.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -11,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-//@RequestMapping("/api/oauth2.0/kakao")
 @RequestMapping("/api/auth/kakao")
 public class KakaoOauthController {
 
     private final KakaoOauthService kakaoOauthService;
+    private final JwtProvider jwtProvider;
 
 
     @GetMapping("/login")
@@ -31,9 +36,29 @@ public class KakaoOauthController {
     }
 
     @GetMapping("/callback")
-    public String callbackKakaoLogin(@RequestParam String code) throws JsonProcessingException {
-        String accessToken = kakaoOauthService.kakaoLogin(code);
+    public ResponseEntity<BaseResponseDto> callbackKakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
 
-        return accessToken;
+        try {
+            OauthLoginResponseDto tokens = kakaoOauthService.kakaoLogin(code);
+
+            // 헤더와 쿠키에 엑세스토큰 과 리프레시 토큰을 저장
+            jwtProvider.addAccessTokenToHeader(response, tokens.getAccessToken());
+            jwtProvider.addRefreshTokenToCookie(response, tokens.getRefreshToken());
+
+            return ResponseEntity.ok()
+                    .body(
+                            BaseResponseDto.baseResponseBuilder()
+                                    .message("로그인 성공")
+                                    .build()
+                    );
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                    .body(
+                            BaseResponseDto.baseResponseBuilder()
+                                    .message("로그인 실패" + e.getMessage())
+                                    .build()
+                    );
+        }
     }
 }

--- a/src/main/java/com/sparta/realtomatoapp/auth/controller/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/controller/resolver/LoginUserArgumentResolver.java
@@ -1,6 +1,5 @@
 package com.sparta.realtomatoapp.auth.controller.resolver;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.realtomatoapp.common.entity.LoginUser;
 import com.sparta.realtomatoapp.user.dto.AuthUser;
 import com.sparta.realtomatoapp.security.config.JwtConfig;
@@ -45,7 +44,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             String token = header.substring(7);
 
             Jws<Claims> claimsJws = Jwts.parser()
-                    .verifyWith(Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes(StandardCharsets.UTF_8)))
+                    .verifyWith(Keys.hmacShaKeyFor(jwtConfig.getJwtAccessTokenSecretKey().getBytes(StandardCharsets.UTF_8)))
                     .build()
                     .parseSignedClaims(token);
 

--- a/src/main/java/com/sparta/realtomatoapp/auth/dto/LoginTokenResponseDto.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/dto/LoginTokenResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.realtomatoapp.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginTokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/realtomatoapp/auth/dto/OauthLoginResponseDto.java
+++ b/src/main/java/com/sparta/realtomatoapp/auth/dto/OauthLoginResponseDto.java
@@ -1,0 +1,15 @@
+ package com.sparta.realtomatoapp.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OauthLoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtConfig.java
@@ -6,17 +6,25 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Getter
 @Component
 @RequiredArgsConstructor
 public class JwtConfig {
 
-    // 토큰의 만료 시간 (분 단위)
+    // 액세스 토큰의 만료 시간 (분 단위)
     @Value("${access.token.expire.time}")
-    private Integer jwtaccesstokenexpiretime;
+    private Integer jwtAccessTokenExpireTime;
 
-    // 서명 키 (secret key)
+    // 액세스 토큰의 서명 키 (secret key)
     @Value("${access.token.secret.key}")
-    private String jwtaccessTokenSecretKey;
+    private String jwtAccessTokenSecretKey;
+
+
+    // 리프레시 토큰의 만료 시간 (분 단위)
+    @Value("${refresh.token.expire.time}")
+    private Integer jwtRefreshTokenExpireTime;
+
+    // 리프레시 토큰의 서명 키 (secret key)
+    @Value("${refresh.token.secret.key}")
+    private String jwtRefreshSecretKey;
 }

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
@@ -36,10 +36,25 @@ public class JwtProvider {
     }
 
     //JWT 토큰 검증
+    // Access Token 유효성 검사
     public boolean verifyAccessToken(String jwtAccessToken) {
-        SecretKey secureAccessSecret = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
+        SecretKey accessTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
+        return verifyToken(jwtAccessToken, accessTokenKey);
+    }
+
+    // Refresh Token 유효성 검사
+    public boolean verifyRefreshToken(String jwtRefreshToken) {
+        SecretKey refreshTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshTokenSecretKey().getBytes());
+        return verifyToken(jwtRefreshToken, refreshTokenKey);
+    }
+
+    private boolean verifyToken(String jwtAccessToken, SecretKey secretKey) {
+//        SecretKey secureAccessSecret = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
         try {
-            Jwts.parser().verifyWith(secureAccessSecret).build().parseSignedClaims(jwtAccessToken);
+            Jwts.parser()
+                    .verifyWith(secureAccessSecret)
+                    .build()
+                    .parseSignedClaims(jwtAccessToken);
             return true;
         } catch (Exception e) {
             return false;

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
@@ -1,8 +1,5 @@
 package com.sparta.realtomatoapp.security.config;
 
-import com.sparta.realtomatoapp.user.dto.AuthUser;
-import com.sparta.realtomatoapp.user.entity.UserRole;
-import com.sparta.realtomatoapp.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -78,5 +75,4 @@ public class JwtProvider {
                 .userId(userId)
                 .build();
     }
-
 }

--- a/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/config/JwtProvider.java
@@ -1,9 +1,11 @@
 package com.sparta.realtomatoapp.security.config;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
+import com.sparta.realtomatoapp.user.dto.AuthUser;
+import com.sparta.realtomatoapp.user.entity.UserRole;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,47 +22,77 @@ public class JwtProvider {
 
     private final JwtConfig jwtConfig;
 
-    //JWT 토큰 생성
+    //JWT 엑세스 토큰 생성
     public String createJwtToken(AuthUser authUser) {
         return Jwts.builder()
                 .subject(authUser.getEmail())
                 .claim("role", authUser.getRole())
                 .claim("userId", authUser.getUserId())
-                .expiration(Date.from(Instant.now().plus(jwtConfig.getJwtaccesstokenexpiretime(), ChronoUnit.MINUTES)))
+                .expiration(Date.from(Instant.now().plus(jwtConfig.getJwtAccessTokenExpireTime(), ChronoUnit.MINUTES)))
                 .issuedAt(Date.from(Instant.now()))
-                .signWith(Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes()), Jwts.SIG.HS256)
+                .signWith(Keys.hmacShaKeyFor(jwtConfig.getJwtAccessTokenSecretKey().getBytes()), Jwts.SIG.HS256)
                 .compact();
     }
+
+    //JWT 엑세스 토큰을 헤더에 담는 메서드
+    public void addAccessTokenToHeader(HttpServletResponse response, String accessToken) {
+        response.addHeader("Authorization", "Bearer " + accessToken);
+    }
+
+    //JWT 리프레시 토큰 생성
+    public String createRefreshToken(AuthUser authUser) {
+        return Jwts.builder()
+                .subject(authUser.getUserId().toString())
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plus(jwtConfig.getJwtRefreshTokenExpireTime(), ChronoUnit.MINUTES)))
+                .signWith(Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshSecretKey().getBytes()), Jwts.SIG.HS256)
+                .compact();
+    }
+
+    //JWT 리프레시 토큰을 쿠키에 담기
+    // 리프레시 토큰을 쿠키에 담아 응답으로 보내는 메서드
+    public void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+//        refreshTokenCookie.setHttpOnly(true);  // JavaScript에서 접근할 수 없게 설정
+//        refreshTokenCookie.setSecure(true);    // HTTPS를 통해서만 전송되도록 설정
+        refreshTokenCookie.setPath("/");       // 쿠키의 유효 범위 설정
+        refreshTokenCookie.setMaxAge(jwtConfig.getJwtRefreshTokenExpireTime());  // 쿠키 만료 시간 = 리프레시 토큰 만료 기간
+
+        response.addCookie(refreshTokenCookie);  // 응답에 쿠키 추가
+    }
+
 
     //JWT 토큰 검증
     // Access Token 유효성 검사
     public boolean verifyAccessToken(String jwtAccessToken) {
-        SecretKey accessTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
+        SecretKey accessTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtAccessTokenSecretKey().getBytes());
         return verifyToken(jwtAccessToken, accessTokenKey);
     }
 
     // Refresh Token 유효성 검사
     public boolean verifyRefreshToken(String jwtRefreshToken) {
-        SecretKey refreshTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshTokenSecretKey().getBytes());
+        SecretKey refreshTokenKey = Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshSecretKey().getBytes());
         return verifyToken(jwtRefreshToken, refreshTokenKey);
     }
 
     private boolean verifyToken(String jwtAccessToken, SecretKey secretKey) {
-//        SecretKey secureAccessSecret = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
         try {
             Jwts.parser()
-                    .verifyWith(secureAccessSecret)
+                    .verifyWith(secretKey)
                     .build()
                     .parseSignedClaims(jwtAccessToken);
             return true;
-        } catch (Exception e) {
+        } catch (ExpiredJwtException e) {
+            return false;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("JWT 형식 오류 or 서명 검증 실패 등 예외 발생", e);
             return false;
         }
     }
 
     // 토큰으로 부터 정보 가져오기
     public AuthUser getCurrentRequestAuthInfo(String jwtAccessToken) {
-        SecretKey secureAccessSecret = Keys.hmacShaKeyFor(jwtConfig.getJwtaccessTokenSecretKey().getBytes());
+        SecretKey secureAccessSecret = Keys.hmacShaKeyFor(jwtConfig.getJwtAccessTokenSecretKey().getBytes());
         Jws<Claims> claimsJws = Jwts.parser().verifyWith(secureAccessSecret).build()
                 .parseSignedClaims(jwtAccessToken);
 

--- a/src/main/java/com/sparta/realtomatoapp/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.sparta.realtomatoapp.security.filter;
 import com.sparta.realtomatoapp.security.config.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @Slf4j
 @Component
@@ -24,34 +26,66 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         //1. 토큰이 필요없는 API
         String requestURI = request.getRequestURI();
-        if (requestURI.contains("/api/auth")) {
+        if (requestURI.contains("/api/auth") || requestURI.contains("/refresh-token")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        //2. 토큰 검증
+        //2. 엑세스 토큰 검증
         String bearerToken = request.getHeader("Authorization");
         String token = null;
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            token =bearerToken.substring("Bearer ".length()); // "Bearer "의 길이가 7이므로 그 뒤의 문자열을 반환
-        }
-
-        if (!jwtProvider.verifyAccessToken(token)) {
+            token = bearerToken.substring("Bearer ".length()); // "Bearer "의 길이가 7이므로 그 뒤의 문자열을 반환
+        } else {
             // 사용자에 잘못된 값 json으로 날림
             unAuthResponse(response);
             return;
         }
 
-        filterChain.doFilter(request, response);
+        // 3. 엑세스 토큰이 유효하다면 다음 필터 수행
+        if (jwtProvider.verifyAccessToken(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
-        //3. 권한 검증 ==>AOP 처리?
+        // 4. 엑세스 토큰이 만료 되었을 경우. 쿠키에 저장된 리프레시 토큰 검증
+        Cookie[] cookies = request.getCookies();
+        String refreshToken = null;
+        if (cookies != null) {
+            refreshToken = Arrays.stream(cookies)
+                    .filter(cookie -> "refresh_token".equals(cookie.getName()))
+                    .map(Cookie::getValue) // 쿠키의 값을 추출
+                    .findFirst() // 첫 번째 매칭되는 값을 찾음
+                    .orElse(null);
+        }
+        if (jwtProvider.verifyRefreshToken(refreshToken)) {
+            refreshResponse(response);
+            return;
+        }
+
+        // 사용자에 잘못된 값 json으로 날림
+        unAuthResponse(response);
+        return;
+
+        //5. 권한 검증 ==>AOP 처리?
     }
 
     private void unAuthResponse(HttpServletResponse response) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드 설정
         response.setContentType("application/json"); // 응답 타입을 JSON으로 설정
         response.setCharacterEncoding("UTF-8");
-        String jsonResponse = "{\"error\": \"토큰이 만료되었습니다.\"}";
+        String jsonResponse = "{\"error\": \"토큰이 만료되었거나 잘못된 형식입니다.\"}";
+        response.getWriter().write(jsonResponse); // 응답 본문에 JSON 메시지 작성
+    }
+
+    private void refreshResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드 설정
+        response.setContentType("application/json"); // 응답 타입을 JSON으로 설정
+        response.setCharacterEncoding("UTF-8");
+        String jsonResponse = "{"
+                + "\"message\": \"엑세스 토큰이 만료되었습니다. 리프레시 토큰을 사용해 새로운 엑세스 토큰을 발급받으세요.\","
+                + "\"refreshTokenUrl\": \"/refresh-token\""
+                + "}";
         response.getWriter().write(jsonResponse); // 응답 본문에 JSON 메시지 작성
     }
 }

--- a/src/main/java/com/sparta/realtomatoapp/security/refreshToken/controller/RefreshTokenController.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/refreshToken/controller/RefreshTokenController.java
@@ -1,0 +1,52 @@
+package com.sparta.realtomatoapp.security.refreshToken.controller;
+
+import com.sparta.realtomatoapp.common.dto.BaseResponseDto;
+import com.sparta.realtomatoapp.security.config.JwtProvider;
+import com.sparta.realtomatoapp.security.refreshToken.service.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+@RestController
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<BaseResponseDto> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+        String refreshToken = Arrays.stream(cookies)
+                .filter(cookie -> "refresh_token".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+        // 리프레시 토큰이 없을 시
+        if(refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(BaseResponseDto.baseResponseBuilder().message("리프레시 토큰이 존재하지 않습니다.").build());
+        }
+
+        // 리프레시 토큰 유효성 검사 실패 시
+        if(!jwtProvider.verifyRefreshToken(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(BaseResponseDto.baseResponseBuilder().message("리프레시 토큰이 유효하지 않습니다.").build());
+        }
+
+        String newAccessToken = refreshTokenService.reissueAccessToken(refreshToken);
+
+
+        // 헤더에 새로운 엑세스 토큰 발급
+        jwtProvider.addAccessTokenToHeader(response, newAccessToken);
+
+        return ResponseEntity.ok(BaseResponseDto.baseResponseBuilder().message("엑세스 토큰 재발급 성공").build());
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/refreshToken/entity/RefreshToken.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/refreshToken/entity/RefreshToken.java
@@ -1,0 +1,31 @@
+package com.sparta.realtomatoapp.security.refreshToken.entity;
+
+import com.sparta.realtomatoapp.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "refresh_token")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String tokenValue;
+
+    @OneToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    public void updateToken(String refreshToken) {
+        this.tokenValue = refreshToken;
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.realtomatoapp.security.refreshToken.repository;
+
+import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
+import com.sparta.realtomatoapp.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUser(User user);
+
+    Optional<RefreshToken> findByTokenValue(String tokenValue);
+
+    void deleteByTokenValue(String tokenValue);
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/refreshToken/service/RefreshTokenService.java
@@ -1,0 +1,65 @@
+package com.sparta.realtomatoapp.security.refreshToken.service;
+
+import com.sparta.realtomatoapp.security.config.JwtConfig;
+import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
+import com.sparta.realtomatoapp.security.refreshToken.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final JwtConfig jwtConfig;
+    private static final long EXPIRING_SOON_THRESHOLD = 24 * 60 * 60 * 1000; // 1일 (밀리초 단위)
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    // Refresh Token 생성 및 데이터베이스에 저장
+    public void createAndStoreRefreshToken(String userEmail, String token) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .token(token)
+                .userEmail(userEmail)
+                .expiryDate(Instant.now().plusMillis(jwtConfig.getJwtRefreshTokenExpireTime() * 60 * 1000))
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    // Refresh Token 유효성 검사
+    public boolean isTokenValid(String token) {
+        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(token);
+        return refreshTokenOpt.isPresent() && refreshTokenOpt.get().getExpiryDate().isAfter(Instant.now());
+    }
+
+    // Refresh Token 무효화
+    public void invalidateRefreshToken(String token) {
+        refreshTokenRepository.deleteByToken(token);
+    }
+
+    // 사용자 이메일로 Refresh Token 조회
+    public Optional<RefreshToken> findTokenByUserEmail(String userEmail) {
+        return refreshTokenRepository.findByUserEmail(userEmail);
+    }
+
+    // 만료 임박 시 새 Refresh Token 발급 필요 여부 확인
+    public boolean isTokenExpiringSoon(String refreshToken) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshTokenSecretKey().getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(refreshToken)
+                .getBody();
+
+        Date expirationDate = claims.getExpiration();
+        long timeRemaining = expirationDate.getTime() - System.currentTimeMillis();
+
+        return timeRemaining < EXPIRING_SOON_THRESHOLD;
+    }
+}

--- a/src/main/java/com/sparta/realtomatoapp/security/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/sparta/realtomatoapp/security/refreshToken/service/RefreshTokenService.java
@@ -1,65 +1,38 @@
 package com.sparta.realtomatoapp.security.refreshToken.service;
 
-import com.sparta.realtomatoapp.security.config.JwtConfig;
+import com.sparta.realtomatoapp.security.config.JwtProvider;
 import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
 import com.sparta.realtomatoapp.security.refreshToken.repository.RefreshTokenRepository;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
+import com.sparta.realtomatoapp.user.dto.AuthUser;
+import com.sparta.realtomatoapp.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.Date;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
 
-    private final JwtConfig jwtConfig;
-    private static final long EXPIRING_SOON_THRESHOLD = 24 * 60 * 60 * 1000; // 1일 (밀리초 단위)
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
 
-    // Refresh Token 생성 및 데이터베이스에 저장
-    public void createAndStoreRefreshToken(String userEmail, String token) {
-        RefreshToken refreshToken = RefreshToken.builder()
-                .token(token)
-                .userEmail(userEmail)
-                .expiryDate(Instant.now().plusMillis(jwtConfig.getJwtRefreshTokenExpireTime() * 60 * 1000))
+    public String reissueAccessToken(String refreshToken) {
+        /*if (!isTokenValid(refreshToken)) {
+            throw new IllegalArgumentException("없는 리프레시 토큰이거나, 저장된 토큰이 유효하지 않습니다.");
+        }*/
+        RefreshToken savedtoken = refreshTokenRepository.findByTokenValue(refreshToken).orElseThrow(
+                () -> new IllegalArgumentException("토큰이 존재하지 않습니다.")
+        );
+        if (!jwtProvider.verifyRefreshToken(savedtoken.getTokenValue())) {
+            refreshTokenRepository.deleteByTokenValue(refreshToken);
+            throw new IllegalArgumentException("저장된 리프레시 토큰이 유효하지 않습니다. 새로 로그인해주세요.");
+        }
+
+        User savedUser = savedtoken.getUser();
+        AuthUser authUser = AuthUser.builder()
+                .email(savedUser.getEmail())
+                .role(savedUser.getRole())
+                .userId(savedUser.getUserId())
                 .build();
-
-        refreshTokenRepository.save(refreshToken);
-    }
-
-    // Refresh Token 유효성 검사
-    public boolean isTokenValid(String token) {
-        Optional<RefreshToken> refreshTokenOpt = refreshTokenRepository.findByToken(token);
-        return refreshTokenOpt.isPresent() && refreshTokenOpt.get().getExpiryDate().isAfter(Instant.now());
-    }
-
-    // Refresh Token 무효화
-    public void invalidateRefreshToken(String token) {
-        refreshTokenRepository.deleteByToken(token);
-    }
-
-    // 사용자 이메일로 Refresh Token 조회
-    public Optional<RefreshToken> findTokenByUserEmail(String userEmail) {
-        return refreshTokenRepository.findByUserEmail(userEmail);
-    }
-
-    // 만료 임박 시 새 Refresh Token 발급 필요 여부 확인
-    public boolean isTokenExpiringSoon(String refreshToken) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(jwtConfig.getJwtRefreshTokenSecretKey().getBytes(StandardCharsets.UTF_8)))
-                .build()
-                .parseClaimsJws(refreshToken)
-                .getBody();
-
-        Date expirationDate = claims.getExpiration();
-        long timeRemaining = expirationDate.getTime() - System.currentTimeMillis();
-
-        return timeRemaining < EXPIRING_SOON_THRESHOLD;
+        return jwtProvider.createJwtToken(authUser);
     }
 }

--- a/src/main/java/com/sparta/realtomatoapp/user/entity/User.java
+++ b/src/main/java/com/sparta/realtomatoapp/user/entity/User.java
@@ -3,6 +3,7 @@ package com.sparta.realtomatoapp.user.entity;
 import com.sparta.realtomatoapp.auth.entity.OauthUser;
 import com.sparta.realtomatoapp.common.entity.ModifiedAuditingEntity;
 import com.sparta.realtomatoapp.order.entity.Order;
+import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
 import com.sparta.realtomatoapp.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
@@ -54,4 +55,7 @@ public class User extends ModifiedAuditingEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OauthUser> oauthUsers;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private RefreshToken refreshTokens;
 }

--- a/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
@@ -63,13 +63,16 @@ public class UserService {
                 .tokenValue(refreshToken)
                 .user(user)
                 .build();
-        // 리프레시 토큰이 없을 시 -> 새로 추가
-        RefreshToken existingRefreshToken = refreshTokenRepository.findByUser(user).orElseGet(() ->
-                refreshTokenRepository.save(refreshEntity));
 
-        // 발급 해준 토큰이 있을 시 -> 변경
-        existingRefreshToken.updateToken(refreshToken);
-        refreshTokenRepository.save(existingRefreshToken);
+        Optional<RefreshToken> existingTokenValue = refreshTokenRepository.findByUser(user);
+        if (existingTokenValue.isEmpty()) {
+            // 발급 해준 토큰이 없을 시 -> 새로 발급
+            refreshTokenRepository.save(refreshEntity);
+        } else {
+            // 발급 해준 토큰이 있을 시 -> 재발급(변경)
+            existingTokenValue.get().updateToken(refreshToken);
+            refreshTokenRepository.save(existingTokenValue.get());
+        }
 
         return LoginTokenResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
@@ -1,21 +1,24 @@
 package com.sparta.realtomatoapp.user.service;
 
 import com.sparta.realtomatoapp.auth.dto.LoginRequestDto;
+import com.sparta.realtomatoapp.auth.dto.LoginTokenResponseDto;
 import com.sparta.realtomatoapp.auth.dto.UserRegistrationRequestDto;
 import com.sparta.realtomatoapp.auth.dto.UserResponseDto;
 import com.sparta.realtomatoapp.security.config.JwtProvider;
 import com.sparta.realtomatoapp.security.exception.CustomException;
 import com.sparta.realtomatoapp.security.exception.eunm.ErrorCode;
+import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
 import com.sparta.realtomatoapp.security.util.PasswordEncoderUtil;
 import com.sparta.realtomatoapp.user.dto.AuthUser;
 import com.sparta.realtomatoapp.user.dto.UserUpdateRequestDto;
-import com.sparta.realtomatoapp.user.repository.UserRepository;
 import com.sparta.realtomatoapp.user.entity.User;
 import com.sparta.realtomatoapp.user.entity.UserRole;
+import com.sparta.realtomatoapp.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,17 +31,14 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoderUtil passwordEncoderUtil;
     private final JwtProvider jwtProvider; // JWT 토큰 생성을 위해 필요
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public Optional<User> findUserByEmail(String email) {
         return userRepository.findByEmail(email);
     }
 
-    public User getUserById(Long userId) {
-        return userRepository.findById(userId).orElseThrow(() ->
-                new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    public String loginUser(LoginRequestDto request) {
+    @Transactional
+    public LoginTokenResponseDto loginUser(LoginRequestDto request) {
         User user = findUserByEmail(request.getEmail()).orElseThrow(() ->
                 new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -53,7 +53,27 @@ public class UserService {
                 .role(user.getRole())
                 .build();
 
-        return jwtProvider.createJwtToken(authUser);
+        String accessToken = jwtProvider.createJwtToken(authUser);
+        // JWT 리프레시 토큰 생성 후 쿠키에 저장
+        String refreshToken = jwtProvider.createRefreshToken(authUser);
+
+        // DB에 리프레시 토큰 저장
+        RefreshToken refreshEntity = RefreshToken.builder()
+                .tokenValue(refreshToken)
+                .user(user)
+                .build();
+        // 리프레시 토큰이 없을 시 -> 새로 추가
+        RefreshToken existingRefreshToken = refreshTokenRepository.findByUser(user).orElseGet(() ->
+                refreshTokenRepository.save(refreshEntity));
+
+        // 발급 해준 토큰이 있을 시 -> 변경
+        existingRefreshToken.updateToken(refreshToken);
+        refreshTokenRepository.save(existingRefreshToken);
+
+        return LoginTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     public UserResponseDto registerUser(UserRegistrationRequestDto request) {
@@ -79,6 +99,12 @@ public class UserService {
         userRepository.save(user);
 
         return convertToDto(user);
+    }
+
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
     public List<UserResponseDto> getAllUsers(int page, int size) {

--- a/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
+++ b/src/main/java/com/sparta/realtomatoapp/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.sparta.realtomatoapp.security.config.JwtProvider;
 import com.sparta.realtomatoapp.security.exception.CustomException;
 import com.sparta.realtomatoapp.security.exception.eunm.ErrorCode;
 import com.sparta.realtomatoapp.security.refreshToken.entity.RefreshToken;
+import com.sparta.realtomatoapp.security.refreshToken.repository.RefreshTokenRepository;
 import com.sparta.realtomatoapp.security.util.PasswordEncoderUtil;
 import com.sparta.realtomatoapp.user.dto.AuthUser;
 import com.sparta.realtomatoapp.user.dto.UserUpdateRequestDto;


### PR DESCRIPTION
# 🍅title: Feat: Add NewsPost🍅 
## 🔘Part 
- Refresh 토큰 기능 추가 

## 🔎 작업 내용 
- 리프레시 토큰으로 엑세스 토큰을 추가해주는 API 추가
- 유저 삭제 시 Soft 딜리트 되도록 변경
- 필터에서 리프레시 토큰을 추가로 검증하도록 로직 변경
- 로그인 시 엑세스 토큰을 헤더에 추가하고, 리프레시 토큰을 쿠키 저장소에 추가하여 발급하도록 변경

## 🔧 앞으로의 과제 
- Oauth 로그인 시에도 똑같이 리프레시토큰을 DB에 저장 & 쿠키 저장소에 발급 되도록 변경 해야 함

## ➕ 이슈 링크 
- [이슈 링크](https://github.com/IwannabeArealTomato/tomato-app/issues/4)